### PR TITLE
32 bit data type for scan interval and scan window and channel info in advertising report

### DIFF
--- a/Include/btle.h
+++ b/Include/btle.h
@@ -103,7 +103,7 @@ typedef enum
 typedef uint16_t btle_adv_interval_t;
 
 /** @brief BTLE scan interval type (_SHALL_ be fully compatible with the type in the HCI). */
-typedef uint16_t btle_scan_interval_t;
+typedef uint32_t btle_scan_interval_t;
 
 /** @brief BTLE connection interval type (_SHALL_ be fully compatible with the type in the HCI). */
 typedef uint16_t btle_conn_interval_t;
@@ -115,7 +115,7 @@ typedef uint16_t btle_connection_handle_t;
 typedef uint16_t btle_data_length_t;
 
 /** @brief BTLE scan window type (_SHALL_ be fully compatible with the type in the HCI). */
-typedef uint16_t btle_scan_window_t;
+typedef uint32_t btle_scan_window_t;
 
 /** @brief BTLE connection latency type (_SHALL_ be fully compatible with the type in the HCI). */
 typedef uint16_t  btle_conn_latency_t;

--- a/Include/btle.h
+++ b/Include/btle.h
@@ -687,6 +687,7 @@ typedef struct
   uint8_t                     length_data;
   uint8_t                     report_data[BTLE_ADVERTISING_DATA__SIZE];
   uint8_t                     rssi;
+  uint8_t					   channel;
 } btle_ev_param_le_advertising_report_t;
 
 typedef struct

--- a/btle_hci/scanner/ll_scan.c
+++ b/btle_hci/scanner/ll_scan.c
@@ -33,6 +33,7 @@
  */
 
 #include "ll_scan.h"
+#include "channel_resolver.h"
 
 #include "btle.h"
 #include "nrf_report_disp.h"
@@ -174,6 +175,7 @@ static void m_adv_report_generate (uint8_t * const pkt)
   bool has_data = false;
   nrf_report_t report;
   btle_ev_param_le_advertising_report_t *adv_report = &report.event.params.le_advertising_report_event;
+  adv_report->channel = channel_resolver_get_channel();
   
   /* Validate the RSSI value. It is 7 bits, so a value above 0x7F is invalid */
   if (m_rssi > 0x7F)


### PR DESCRIPTION
The fields in the struct nrf_radio_request_earliest_t in nrf_soc.h are 32 bit long so even the values in btle.h have to be 32 bit long otherwise the behaviour is not correct. I have checked it looking at the power profile while scanning and noticed that the interval between scans was not correct.
I haven't checked for the advertising but I expect a similar problem.
