### PR TITLE
Removed trailing ^M token (line-ending issue?)

### DIFF
--- a/btle_hci/scanner/ll_scan.c
+++ b/btle_hci/scanner/ll_scan.c
@@ -208,7 +208,7 @@ static void m_adv_report_generate (uint8_t * const pkt)
   #define UL_PDU_DD_SENDER_PADD_MASK          BIT_6
   #define UL_PDU_DD_SENDER_PADD_SHIFT         6
   
-  adv_report->address_type = (pkt[UL_PDU_DD_SENDER_PADD_OFFSET] & UL_PDU_DD_SENDER_PADD_MASK) >> UL_PDU_DD_SENDER_PADD_SHIFT;^M
+  adv_report->address_type = (pkt[UL_PDU_DD_SENDER_PADD_OFFSET] & UL_PDU_DD_SENDER_PADD_MASK) >> UL_PDU_DD_SENDER_PADD_SHIFT;
   adv_report->rssi = m_rssi;
   
   adv_report->length_data = (adv_report->length_data       ) - BTLE_DEVICE_ADDRESS__SIZE;


### PR DESCRIPTION
nrf51-multi-role-conn-observer-advertiser/btle_hci/scanner/ll_scan.c: In function 'm_adv_report_generate':
nrf51-multi-role-conn-observer-advertiser/btle_hci/scanner/ll_scan.c:211:126: error: expected expression before '^' token
   adv_report->address_type = (pkt[UL_PDU_DD_SENDER_PADD_OFFSET] & UL_PDU_DD_SENDER_PADD_MASK) >> UL_PDU_DD_SENDER_PADD_SHIFT;^M
                                                                                                                              ^